### PR TITLE
devel/poedit (1.5.7_3)

### DIFF
--- a/devel/poedit/Portfile
+++ b/devel/poedit/Portfile
@@ -1,0 +1,78 @@
+ # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           wxWidgets 1.0
+
+name                poedit
+version             1.5.7
+revision            3
+categories          devel aqua
+platforms           darwin
+license             MIT
+maintainers         openmaintainer
+
+description         (pegged) Poedit is a cross-platform gettext catalogs (.po files) editor.
+long_description    (pegged) Poedit is a cross-platform gettext catalogs (.po files) editor. It aims to \
+                    provide more convenient approach to editing catalogs than editing the file by \
+                    hand. This port installs Poedit.app.
+
+homepage            http://www.poedit.net/
+master_sites        sourceforge:poedit
+
+checksums           md5     f5b53ec66a606f088b0aa388595ea5f9 \
+                    sha1    e83c08ca33997829be946e1dcf1a35149856d184 \
+                    rmd160  46436e98caf2b41b61188fc1b79db62f2f218817 \
+                    sha256  24535cac22c8f7fb4f995710f6638ebc26825056076a04210ee66e19d65c0f78
+
+wxWidgets.use       wxWidgets-3.0
+
+depends_build       bin:grep:grep \
+                    port:pkgconfig \
+                    port:boost
+depends_lib         port:gettext \
+                    port:${wxWidgets.port}
+
+depends_skip_archcheck grep pkgconfig boost
+
+# remove some additional features, especially sparkle because macports handles updates
+configure.args      --disable-spellchecking \
+                    --disable-transmem \
+                    --without-sparkle \
+                    --with-wxdir=${wxWidgets.wxdir}
+
+build.dir           ${build.dir}/src
+build.target        bundle
+build.env-append    GETTEXT_PREFIX=${prefix} \
+                    WX_ROOT=${wxWidgets.prefix}
+
+destroot {
+    # the gettext binaries are copied into Poedit.app during build,
+    # but we rather delete and symlink them to get updates to gettext automatically
+    foreach extra { msgfmt msgmerge msgunfmt xgettext } {
+        file delete ${worksrcpath}/src/Poedit.app/Contents/MacOS/${extra}
+        ln -s ${prefix}/bin/${extra} ${worksrcpath}/src/Poedit.app/Contents/MacOS/${extra}
+    }
+    file delete ${worksrcpath}/src/Poedit.app/Contents/MacOS/gnu_gettext.COPYING
+
+    file copy ${worksrcpath}/src/Poedit.app ${destroot}${applications_dir}/Poedit.app
+}
+
+variant transmem description {Enables translation memory for often used phrases} {
+    depends_lib-append      port:db44
+    configure.args-delete   --disable-transmem
+    configure.args-append   --enable-transmem
+}
+
+variant spellcheck description {Enables spellchecking} {
+    depends_lib-append      port:gtkspell2
+    configure.args-delete   --disable-spellchecking
+    configure.args-append   --enable-spellchecking
+}
+
+#livecheck.type      regex
+#livecheck.url       http://www.poedit.net/download.php
+#livecheck.regex     ${name}-(\\d+(\\.\\d+)+)\\.tar
+
+
+# Portfile from: https://github.com/macports/macports-ports/blob/7ff4367cb6c1b4725784df4d4500f46ee3a1374a/devel/poedit/Portfile
+# Last one before it was removed: https://github.com/macports/macports-ports/commit/e70cecc5b3e9ffe4fcaf4d61dd781872833bd06d


### PR DESCRIPTION
Poedit is now "<= 10.10": https://github.com/macports/macports-ports/commit/bee84cbd878c66ff012153764b60011462a0be1b

This was the last Portfile, before the old one was removed: https://github.com/macports/macports-ports/commit/e70cecc5b3e9ffe4fcaf4d61dd781872833bd06d